### PR TITLE
fix: reverted containers patches

### DIFF
--- a/vendor/github.com/containers/image/v5/image/unparsed.go
+++ b/vendor/github.com/containers/image/v5/image/unparsed.go
@@ -55,7 +55,7 @@ func (i *UnparsedImage) Manifest(ctx context.Context) ([]byte, string, error) {
 			if err != nil {
 				return nil, "", errors.Wrap(err, "computing manifest digest")
 			}
-			if !matches {
+			if i.Reference().Transport().Name() != "docker-daemon" && !matches {
 				return nil, "", errors.Errorf("Manifest does not match provided manifest digest %s", digest)
 			}
 		}


### PR DESCRIPTION
Outcome of `git restore --source=3f98f94d37e54c8af184cc51d6402a086d1e3e7c vendor/github.com/containers/image/v5/image/unparsed.go` 